### PR TITLE
Added link to release, rather than repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Open powershell as administrator and run the following
 ```
 
 # Installation
-- Download the latest Arch.zip release from the ArchWSL repo https://github.com/yuk7/ArchWSL
+- Download the latest Arch.zip release from the ArchWSL repo https://github.com/yuk7/ArchWSL/releases
 - Extract Arch.zip to C:\Users\USERNAME\Documents\Arch
 - Run C:\Users\USERNAME\Documents\Arch\Arch.exe the first time to install
 - Run Arch.exe again to spawn a shell


### PR DESCRIPTION
Prevents users from accidentally downloading the source repo, without the .exe